### PR TITLE
Fix SPM errors and warnings under Xcode 12.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/__PRODUCT_NAME__/.swiftpm
+

--- a/src/__PRODUCT_NAME__/Package.swift
+++ b/src/__PRODUCT_NAME__/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.3
 //
 //  Package.swift
 //  __PRODUCT_NAME__
@@ -37,9 +38,11 @@ let package = Package(
     targets: [
         .target(
             name: "__PRODUCT_NAME__",
-            dependencies: []),
+            dependencies: [],
+            exclude: ["Info.plist"]),
         .testTarget(
             name: "__PRODUCT_NAME__Tests",
-            dependencies: ["__PRODUCT_NAME__"]),
+            dependencies: ["__PRODUCT_NAME__"],
+            exclude: ["Info.plist"]),
     ]
 )


### PR DESCRIPTION
Add `swift-tools-version` comment
Add `exclude` argument to exclude `Info.plist` when building with SPM